### PR TITLE
feat: add simple React EPUB viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# codex_test2
+# EPUB Viewer
+
+Simple React + TypeScript web app that lets users upload an EPUB file and display its text content.
+
+## Development
+
+1. Run `npm run build` to compile TypeScript.
+2. Start a local server with `npm start`.
+3. Open [http://localhost:3000](http://localhost:3000) in a browser.

--- a/dist/main.js
+++ b/dist/main.js
@@ -1,0 +1,23 @@
+// @ts-nocheck
+function App() {
+    const [text, setText] = React.useState("");
+    const handleFile = async (event) => {
+        var _a, _b;
+        const file = (_a = event.target.files) === null || _a === void 0 ? void 0 : _a[0];
+        if (!file)
+            return;
+        const arrayBuffer = await file.arrayBuffer();
+        const zip = await JSZip.loadAsync(arrayBuffer);
+        const names = Object.keys(zip.files).filter((n) => n.endsWith(".xhtml") || n.endsWith(".html"));
+        names.sort();
+        let content = "";
+        for (const name of names) {
+            const fileData = await zip.files[name].async("string");
+            const doc = new DOMParser().parseFromString(fileData, "application/xhtml+xml");
+            content += (((_b = doc.body) === null || _b === void 0 ? void 0 : _b.textContent) || "") + "\n";
+        }
+        setText(content);
+    };
+    return (React.createElement('div', null, React.createElement('h1', null, 'EPUB Viewer'), React.createElement('input', { type: 'file', accept: '.epub', onChange: handleFile }), React.createElement('pre', { style: { whiteSpace: 'pre-wrap' } }, text)));
+}
+ReactDOM.render(React.createElement(App), document.getElementById('root'));

--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>EPUB Viewer</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="https://cdn.jsdelivr.net/npm/react@18/umd/react.production.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"></script>
+  <script type="module" src="./dist/main.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "codex_test2",
+  "version": "1.0.0",
+  "description": "Basic React + TypeScript EPUB viewer",
+  "scripts": {
+    "build": "tsc",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,34 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const port = process.env.PORT || 3000;
+
+const mimeTypes = {
+  '.html': 'text/html',
+  '.js': 'application/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.map': 'application/json'
+};
+
+const server = http.createServer((req, res) => {
+  const requestedPath = req.url === '/' ? '/index.html' : req.url;
+  const filePath = path.join(__dirname, requestedPath);
+
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+    const ext = path.extname(filePath);
+    const contentType = mimeTypes[ext] || 'application/octet-stream';
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(data);
+  });
+});
+
+server.listen(port, () => {
+  console.log(`Server running at http://localhost:${port}`);
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,35 @@
+// @ts-nocheck
+
+declare var React: any;
+declare var ReactDOM: any;
+declare var JSZip: any;
+
+function App() {
+  const [text, setText] = React.useState("");
+
+  const handleFile = async (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    const arrayBuffer = await file.arrayBuffer();
+    const zip = await JSZip.loadAsync(arrayBuffer);
+    const names = Object.keys(zip.files).filter((n) => n.endsWith(".xhtml") || n.endsWith(".html"));
+    names.sort();
+    let content = "";
+    for (const name of names) {
+      const fileData = await zip.files[name].async("string");
+      const doc = new DOMParser().parseFromString(fileData, "application/xhtml+xml");
+      content += (doc.body?.textContent || "") + "\n";
+    }
+    setText(content);
+  };
+
+  return (
+    React.createElement('div', null,
+      React.createElement('h1', null, 'EPUB Viewer'),
+      React.createElement('input', { type: 'file', accept: '.epub', onChange: handleFile }),
+      React.createElement('pre', { style: { whiteSpace: 'pre-wrap' } }, text)
+    )
+  );
+}
+
+ReactDOM.render(React.createElement(App), document.getElementById('root'));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "es2020",
+    "jsx": "react",
+    "strict": false,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- add React+TypeScript app that uploads EPUB files and extracts text with JSZip
- serve the app locally via a small Node static server
- document build and run steps

## Testing
- `npm run build`
- `npm start` (launched server)


------
https://chatgpt.com/codex/tasks/task_e_68b631f3e63c8320a02052c9d55a458f