### PR TITLE
Add highlight removal and notes tab

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -50,10 +50,14 @@ function App() {
     const [fontSize, setFontSize] = React.useState(16);
     const [menuVisible, setMenuVisible] = React.useState(false);
     const [menuPos, setMenuPos] = React.useState({ x: 0, y: 0 });
+    const [highlightTarget, setHighlightTarget] = React.useState(null);
+    const [notes, setNotes] = React.useState([]);
+    const [activeTab, setActiveTab] = React.useState('chapters');
     const handleSelection = (event) => {
         const selection = window.getSelection();
         if (selection && !selection.isCollapsed) {
             setMenuPos({ x: event.clientX, y: event.clientY });
+            setHighlightTarget(null);
             setMenuVisible(true);
         }
         else {
@@ -66,21 +70,53 @@ function App() {
             const range = selection.getRangeAt(0);
             const span = document.createElement('span');
             span.className = 'highlight';
+            const id = String(Date.now() + Math.random());
+            span.dataset.noteId = id;
             try {
                 range.surroundContents(span);
             }
             catch (err) {
                 /* ignore */
             }
+            const text = range.toString();
+            setNotes((prev) => [...prev, { id, text }]);
             selection.removeAllRanges();
             setMenuVisible(false);
         }
     };
+    const handleHighlightClick = (event) => {
+        const target = event.target;
+        if (target && target.classList && target.classList.contains('highlight')) {
+            setMenuPos({ x: event.clientX, y: event.clientY });
+            setHighlightTarget(target);
+            setMenuVisible(true);
+            event.stopPropagation();
+        }
+    };
+    const removeHighlight = () => {
+        if (highlightTarget) {
+            const id = highlightTarget.dataset.noteId;
+            setNotes((prev) => prev.filter((n) => n.id !== id));
+            const parent = highlightTarget.parentNode;
+            while (highlightTarget.firstChild) {
+                parent.insertBefore(highlightTarget.firstChild, highlightTarget);
+            }
+            parent.removeChild(highlightTarget);
+            setHighlightTarget(null);
+            setMenuVisible(false);
+        }
+    };
     React.useEffect(() => {
-        const hideMenu = () => setMenuVisible(false);
+        const hideMenu = () => {
+            setMenuVisible(false);
+            setHighlightTarget(null);
+        };
         document.addEventListener('mousedown', hideMenu);
         return () => document.removeEventListener('mousedown', hideMenu);
     }, []);
+    React.useEffect(() => {
+        setNotes([]);
+    }, [currentBook]);
     const handleFiles = async (event) => {
         const files = Array.from(event.target.files || []);
         const loaded = [];
@@ -143,25 +179,37 @@ function App() {
             setCurrentBook(null);
             setCurrentChapter(0);
             setCurrentPage(0);
+            setActiveTab('chapters');
         },
-    }, 'Back'), React.createElement('ul', null, book.chapters.map((c, i) => React.createElement('li', {
-        key: i,
-        onClick: () => {
-            setCurrentChapter(i);
-            setCurrentPage(0);
-        },
-        style: { fontWeight: i === currentChapter ? 'bold' : 'normal', cursor: 'pointer', marginBottom: '0.5rem' },
-    }, c.title)))), React.createElement('div', { className: 'content' }, React.createElement('div', {
+    }, 'Back'), React.createElement('div', { className: 'tabs' }, React.createElement('button', {
+        onClick: () => setActiveTab('chapters'),
+        style: { fontWeight: activeTab === 'chapters' ? 'bold' : 'normal' },
+    }, 'Chapters'), React.createElement('button', {
+        onClick: () => setActiveTab('notes'),
+        style: { fontWeight: activeTab === 'notes' ? 'bold' : 'normal' },
+    }, 'Notes')), activeTab === 'chapters'
+        ? React.createElement('ul', null, book.chapters.map((c, i) => React.createElement('li', {
+            key: i,
+            onClick: () => {
+                setCurrentChapter(i);
+                setCurrentPage(0);
+            },
+            style: { fontWeight: i === currentChapter ? 'bold' : 'normal', cursor: 'pointer', marginBottom: '0.5rem' },
+        }, c.title)))
+        : React.createElement('ul', { className: 'notes' }, notes.map((n) => React.createElement('li', { key: n.id }, n.text)))), React.createElement('div', { className: 'content' }, React.createElement('div', {
         className: 'page',
         style: { fontSize },
         dangerouslySetInnerHTML: { __html: page },
         onMouseUp: handleSelection,
+        onClick: handleHighlightClick,
     }), menuVisible
         ? React.createElement('div', {
             className: 'selection-menu',
             style: { top: menuPos.y, left: menuPos.x },
             onMouseDown: (e) => e.stopPropagation(),
-        }, React.createElement('button', { onClick: applyHighlight }, 'Highlight'))
+        }, highlightTarget
+            ? React.createElement('button', { onClick: removeHighlight }, 'Unhighlight')
+            : React.createElement('button', { onClick: applyHighlight }, 'Highlight'))
         : null, React.createElement('div', { className: 'controls' }, React.createElement('button', { onClick: () => setCurrentPage((p) => Math.max(p - 1, 0)), disabled: currentPage === 0 }, 'Prev'), React.createElement('span', null, `${currentPage + 1}/${chapter.pages.length}`), React.createElement('button', {
         onClick: () => setCurrentPage((p) => Math.min(p + 1, chapter.pages.length - 1)),
         disabled: currentPage >= chapter.pages.length - 1,

--- a/styles.css
+++ b/styles.css
@@ -87,4 +87,24 @@ body {
 
 .highlight {
   background-color: yellow;
+  cursor: pointer;
+}
+
+.tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.tabs button {
+  flex: 1;
+}
+
+.notes {
+  list-style: none;
+  padding: 0;
+}
+
+.notes li {
+  margin-bottom: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- Allow clicking on existing highlights to open a menu for removing the highlight
- Introduce a Notes tab beside chapters to list all highlighted text
- Style highlights, new tabs, and notes list

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b690fe2ab48320bb8f5daef89e664d