### PR TITLE
Persist books and highlights and enhance reader styling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,6 +1,7 @@
 body {
   font-family: sans-serif;
   margin: 0;
+  text-align: center;
 }
 
 #root {
@@ -10,6 +11,10 @@ body {
 .library {
   list-style: none;
   padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
 }
 
 .library li {
@@ -19,13 +24,15 @@ body {
   margin-bottom: 0.5rem;
   border-radius: 4px;
   display: flex;
+  flex-direction: column;
   align-items: center;
   gap: 0.5rem;
+  width: 150px;
 }
 
 .library li img {
-  width: 40px;
-  height: 60px;
+  width: 120px;
+  height: 180px;
   object-fit: cover;
   border: 1px solid #ccc;
 }
@@ -36,7 +43,7 @@ body {
 }
 
 .sidebar {
-  width: 20%;
+  width: 250px;
   border-right: 1px solid #ccc;
   padding: 1rem;
   overflow-y: auto;
@@ -48,12 +55,23 @@ body {
   overflow-y: auto;
   display: flex;
   flex-direction: column;
+  align-items: center;
 }
 
 .page {
   flex: 1;
   text-align: justify;
   line-height: 1.6;
+  width: 100%;
+}
+
+.page h1,
+.page h2,
+.page h3,
+.page h4,
+.page h5,
+.page h6 {
+  text-align: center;
 }
 
 .controls {
@@ -61,6 +79,7 @@ body {
   display: flex;
   gap: 0.5rem;
   align-items: center;
+  justify-content: center;
 }
 
 .selection-menu {


### PR DESCRIPTION
## Summary
- Save uploaded books and highlight notes in localStorage for persistent library and annotations.
- Preserve EPUB chapter headings and render them as centered headers while reapplying stored highlights.
- Refine layout with centered content, larger book covers, and expanded reading area.

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b692c961cc83209e802b81e73fffda