### PR TITLE
Persist books and notes in localStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Simple React + TypeScript web app that lets users upload an EPUB file and displa
 - Displays book covers extracted from the EPUB in the library
 - Renders chapters with basic EPUB structure and avoids splitting words across pages
 - Remembers the last read page in `localStorage`
+- Persists uploaded books and highlight notes in `localStorage`
 
 ## Development
 


### PR DESCRIPTION
## Summary
- add safe helpers to read/write localStorage
- persist books, notes, and progress using helpers
- document localStorage persistence in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6997732b083208861903116556788