### PR TITLE
Persist books and notes in localStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Simple React + TypeScript web app that lets users upload an EPUB file and displa
 - Displays book covers extracted from the EPUB in the library
 - Renders chapters with basic EPUB structure and avoids splitting words across pages
 - Remembers the last read page in `localStorage`
+- Persists uploaded books and highlight notes in `localStorage`
 
 ## Development
 

--- a/dist/main.js
+++ b/dist/main.js
@@ -1,5 +1,22 @@
 // @ts-nocheck
 const PAGE_SIZE = 1500;
+function safeGetItem(key, fallback) {
+    try {
+        const raw = localStorage.getItem(key);
+        return raw ? JSON.parse(raw) : fallback;
+    }
+    catch (_a) {
+        return fallback;
+    }
+}
+function safeSetItem(key, value) {
+    try {
+        localStorage.setItem(key, JSON.stringify(value));
+    }
+    catch (_a) {
+        /* ignore write errors */
+    }
+}
 function splitIntoPages(doc, size) {
     var _a;
     const blocks = Array.from(((_a = doc.body) === null || _a === void 0 ? void 0 : _a.children) || []);
@@ -50,14 +67,7 @@ function splitIntoPages(doc, size) {
     return pages;
 }
 function App() {
-    const [books, setBooks] = React.useState(() => {
-        try {
-            return JSON.parse(localStorage.getItem('books') || '[]');
-        }
-        catch (_a) {
-            return [];
-        }
-    });
+    const [books, setBooks] = React.useState(() => safeGetItem('books', []));
     const [currentBook, setCurrentBook] = React.useState(null);
     const [currentChapter, setCurrentChapter] = React.useState(0);
     const [currentPage, setCurrentPage] = React.useState(0);
@@ -67,6 +77,9 @@ function App() {
     const [highlightTarget, setHighlightTarget] = React.useState(null);
     const [notes, setNotes] = React.useState([]);
     const [activeTab, setActiveTab] = React.useState('chapters');
+    const book = currentBook !== null ? books[currentBook] : null;
+    const chapter = book ? book.chapters[currentChapter] : null;
+    const page = chapter ? chapter.pages[currentPage] : '';
     const handleSelection = (event) => {
         const selection = window.getSelection();
         if (selection && !selection.isCollapsed) {
@@ -117,21 +130,16 @@ function App() {
     }, []);
     React.useEffect(() => {
         if (book) {
-            try {
-                setNotes(JSON.parse(localStorage.getItem(`notes-${book.title}`) || '[]'));
-            }
-            catch (_a) {
-                setNotes([]);
-            }
+            setNotes(safeGetItem(`notes-${book.title}`, []));
         }
     }, [book]);
     React.useEffect(() => {
         if (book) {
-            localStorage.setItem(`notes-${book.title}`, JSON.stringify(notes));
+            safeSetItem(`notes-${book.title}`, notes);
         }
     }, [notes, book]);
     React.useEffect(() => {
-        localStorage.setItem('books', JSON.stringify(books));
+        safeSetItem('books', books);
     }, [books]);
     const handleFiles = async (event) => {
         const files = Array.from(event.target.files || []);
@@ -167,9 +175,6 @@ function App() {
         setBooks((prev) => [...prev, ...loaded]);
         event.target.value = '';
     };
-    const book = currentBook !== null ? books[currentBook] : null;
-    const chapter = book ? book.chapters[currentChapter] : null;
-    const page = chapter ? chapter.pages[currentPage] : '';
     const pageWithHighlights = React.useMemo(() => {
         let html = page;
         for (const n of notes) {
@@ -180,14 +185,17 @@ function App() {
     }, [page, notes]);
     React.useEffect(() => {
         if (book) {
-            localStorage.setItem(`progress-${book.title}`, JSON.stringify({ chapter: currentChapter, page: currentPage }));
+            safeSetItem(`progress-${book.title}`, {
+                chapter: currentChapter,
+                page: currentPage,
+            });
         }
     }, [book, currentChapter, currentPage]);
     if (!book) {
         return React.createElement('div', null, React.createElement('h1', null, 'My Library'), React.createElement('input', { type: 'file', multiple: true, accept: '.epub', onChange: handleFiles }), React.createElement('ul', { className: 'library' }, books.map((b, i) => React.createElement('li', {
             key: i,
             onClick: () => {
-                const progress = JSON.parse(localStorage.getItem(`progress-${b.title}`) || '{}');
+                const progress = safeGetItem(`progress-${b.title}`, {});
                 setCurrentBook(i);
                 setCurrentChapter(progress.chapter || 0);
                 setCurrentPage(progress.page || 0);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,23 @@ declare var JSZip: any;
 
 const PAGE_SIZE = 1500;
 
+function safeGetItem(key, fallback) {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? JSON.parse(raw) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function safeSetItem(key, value) {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    /* ignore write errors */
+  }
+}
+
 function splitIntoPages(doc, size) {
   const blocks = Array.from(doc.body?.children || []);
   const pages = [];
@@ -60,13 +77,7 @@ function splitIntoPages(doc, size) {
 }
 
 function App() {
-  const [books, setBooks] = React.useState(() => {
-    try {
-      return JSON.parse(localStorage.getItem('books') || '[]');
-    } catch {
-      return [];
-    }
-  });
+  const [books, setBooks] = React.useState(() => safeGetItem('books', []));
   const [currentBook, setCurrentBook] = React.useState(null);
   const [currentChapter, setCurrentChapter] = React.useState(0);
   const [currentPage, setCurrentPage] = React.useState(0);
@@ -76,6 +87,10 @@ function App() {
   const [highlightTarget, setHighlightTarget] = React.useState(null);
   const [notes, setNotes] = React.useState([]);
   const [activeTab, setActiveTab] = React.useState('chapters');
+
+  const book = currentBook !== null ? books[currentBook] : null;
+  const chapter = book ? book.chapters[currentChapter] : null;
+  const page = chapter ? chapter.pages[currentPage] : '';
 
   const handleSelection = (event) => {
     const selection = window.getSelection();
@@ -131,22 +146,18 @@ function App() {
 
   React.useEffect(() => {
     if (book) {
-      try {
-        setNotes(JSON.parse(localStorage.getItem(`notes-${book.title}`) || '[]'));
-      } catch {
-        setNotes([]);
-      }
+      setNotes(safeGetItem(`notes-${book.title}`, []));
     }
   }, [book]);
 
   React.useEffect(() => {
     if (book) {
-      localStorage.setItem(`notes-${book.title}`, JSON.stringify(notes));
+      safeSetItem(`notes-${book.title}`, notes);
     }
   }, [notes, book]);
 
   React.useEffect(() => {
-    localStorage.setItem('books', JSON.stringify(books));
+    safeSetItem('books', books);
   }, [books]);
 
   const handleFiles = async (event) => {
@@ -191,9 +202,6 @@ function App() {
     event.target.value = '';
   };
 
-  const book = currentBook !== null ? books[currentBook] : null;
-  const chapter = book ? book.chapters[currentChapter] : null;
-  const page = chapter ? chapter.pages[currentPage] : '';
   const pageWithHighlights = React.useMemo(() => {
     let html = page;
     for (const n of notes) {
@@ -211,10 +219,10 @@ function App() {
 
   React.useEffect(() => {
     if (book) {
-      localStorage.setItem(
-        `progress-${book.title}`,
-        JSON.stringify({ chapter: currentChapter, page: currentPage })
-      );
+      safeSetItem(`progress-${book.title}`, {
+        chapter: currentChapter,
+        page: currentPage,
+      });
     }
   }, [book, currentChapter, currentPage]);
 
@@ -233,9 +241,7 @@ function App() {
             {
               key: i,
               onClick: () => {
-                const progress = JSON.parse(
-                  localStorage.getItem(`progress-${b.title}`) || '{}'
-                );
+                const progress = safeGetItem(`progress-${b.title}`, {});
                 setCurrentBook(i);
                 setCurrentChapter(progress.chapter || 0);
                 setCurrentPage(progress.page || 0);


### PR DESCRIPTION
## Summary
- add safe helpers to read/write localStorage
- persist books, notes, and progress using helpers
- compute current book, chapter, and page before hooks to avoid runtime errors
- document localStorage persistence in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6997732b083208861903116556788